### PR TITLE
Fix Firebase key encoding for filenames

### DIFF
--- a/my-collab-code-editor/src/editor.js
+++ b/my-collab-code-editor/src/editor.js
@@ -257,7 +257,7 @@ function loadFiles() {
     if (!snapshot.exists() || !filesData || Object.keys(filesData || {}).length === 0) {
       // Create default file with properly encoded name
       const defaultFileName = "untitled.js";
-      const encodedFileName = encodeURIComponent(defaultFileName);
+      const encodedFileName = encodeFirebaseKey(defaultFileName);
       
       console.log("Creating default file with encoded name:", encodedFileName);
       
@@ -293,7 +293,7 @@ function createFileModel(fileName, content, fileType) {
     isLocalChange = true;
     const newVal = model.getValue();
     // Encode the fileName for Firebase key usage.
-    const encodedFileName = encodeURIComponent(fileName);
+    const encodedFileName = encodeFirebaseKey(fileName);
     const fileRef = ref(db, `users/${currentUser.uid}/projects/${currentProjectId}/files/${encodedFileName}`);
     
     onValue(fileRef, (snap) => {

--- a/my-collab-code-editor/src/fileIO.js
+++ b/my-collab-code-editor/src/fileIO.js
@@ -22,6 +22,16 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getDatabase(app);
 
+// Encode filenames safely for Firebase keys
+function encodeFirebaseKey(fileName) {
+    return encodeURIComponent(fileName)
+        .replace(/\./g, '%2E')
+        .replace(/\#/g, '%23')
+        .replace(/\$/g, '%24')
+        .replace(/\[/g, '%5B')
+        .replace(/\]/g, '%5D');
+}
+
 /**
  * Create a new project under the user's account.
  * @param {string} uid User ID of the current user
@@ -54,7 +64,7 @@ export async function deleteProject(uid, projectId) {
 
 export function createFile(uid, projectId, fileName, initialContent = "") {
     // Encode the file name before using it as a key.
-    const encodedFileName = encodeURIComponent(fileName);
+    const encodedFileName = encodeFirebaseKey(fileName);
     const fileRef = ref(db, `users/${uid}/projects/${projectId}/files/${encodedFileName}`);
     const ext = fileName.toLowerCase().split(".").pop();
     const fileType = inferLanguage(ext);


### PR DESCRIPTION
## Change Summary
- correct filename encoding when saving to Firebase
- add shared helper in fileIO